### PR TITLE
Add ETHZ CS Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,11 @@ _______
 
 _______
 
+### CS Courses and Curricula
+- [ETHZ CS Notes](https://cs.shivi.io/) - A full set of well-organized lecture notes and resources following ETH Zurich's computer science curriculum.
+
+_______
+
 <!-- YOUR_CONTENT_GOES_HERE -->
 
 


### PR DESCRIPTION
Adds a link to my ETH Zürich aligned undergraduate CS lecture notes site :D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new "CS Courses and Curricula" section to the README, featuring a link to ETH Zurich CS lecture notes and resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->